### PR TITLE
Fixed that disabled buttons still have tooltips

### DIFF
--- a/serverAddons/PRA3/addons/PRA3_Server/RespawnUI/fn_showDisplayInterruptEH.sqf
+++ b/serverAddons/PRA3/addons/PRA3_Server/RespawnUI/fn_showDisplayInterruptEH.sqf
@@ -32,6 +32,7 @@ private _dialog = findDisplay 49;
 // Disable all buttons first
 for "_i" from 100 to 2000 do {
     (_dialog displayCtrl _i) ctrlEnable false;
+    (_dialog displayCtrl _i) ctrlSetTooltip "";
 };
 
 private _control = _dialog displayCtrl 104;


### PR DESCRIPTION
### When merged this pull request will:

1. Remove tooltips from all disabled controls in the "self-rendered" pause-menu (Esc-Menu)

---